### PR TITLE
Packaging improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [lib]
 name = "tantivy"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-py"
-version = "0.1.0"
+version = "0.10.1"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2018"
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setup(
     name="tantivy",
-    version="0.9.1",
+    version="0.10.1",
     rust_extensions=[RustExtension("tantivy.tantivy", binding=Binding.PyO3)],
     packages=["tantivy"],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+from os import path
 
 try:
     from setuptools_rust import Binding, RustExtension
@@ -6,10 +7,21 @@ except ImportError:
     print("Please install setuptools-rust package")
     raise SystemExit(1)
 
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
 setup(
     name="tantivy",
     version="0.10.1",
     rust_extensions=[RustExtension("tantivy.tantivy", binding=Binding.PyO3)],
     packages=["tantivy"],
+    description=("Python bindings for the Tantivy full-text search engine "
+                 "library"),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license="MIT",
+
     zip_safe=False,
 )


### PR DESCRIPTION
This PR improves the packaging situation of the bindings. It brings the version numbers to be the same as Tantivy, enables the use of pyo3-pack and adds the README to the long description of the python package.

A source distribution can be built the usual python way using:

    python setup.py sdist

The source package can then be uploaded to pypi with twine, an example of such a package can be found [here](https://test.pypi.org/project/tantivy/) (ignore the incorrect version number, pypi doesn't allow a package to be re-uploaded with the same version)