### PR TITLE
Release GIL on searcher acquisition.

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -261,9 +261,9 @@ impl Index {
     /// you probably should configure the Index to have a larger
     /// searcher pool, or you are holding references to previous searcher
     /// for ever.
-    fn searcher(&self) -> Searcher {
+    fn searcher(&self, py: Python) -> Searcher {
         Searcher {
-            inner: self.reader.searcher(),
+            inner: py.allow_threads(|| self.reader.searcher()),
         }
     }
 


### PR DESCRIPTION
I'm not really sure if this is appropriate, but the searchers queue is a blocking queue so it should be a good idea to give another thread a chance to run here.